### PR TITLE
Issue29

### DIFF
--- a/include/LcioMergeTool.h
+++ b/include/LcioMergeTool.h
@@ -74,7 +74,7 @@ class LcioMergeTool {
 
                 bool accept(EVENT::LCEvent* event) {
                     auto hits = event->getCollection(collName_);
-                    float e;
+                    float e=0;
                     for (int iElem = 0; iElem < hits->getNumberOfElements(); iElem++) {
                         EVENT::SimCalorimeterHit* hit =
                                 static_cast<EVENT::SimCalorimeterHit*>(hits->getElementAt(iElem));

--- a/include/UserTrackingAction.h
+++ b/include/UserTrackingAction.h
@@ -68,9 +68,13 @@ class UserTrackingAction : public G4UserTrackingAction {
 
             // Save tracks with tracker hits.
             // This flag is used by LCDD tracker detectors.
-            //if (info->hasTrackerHit()) {
-                // info->setSaveFlag(true);  /// ====> This effectively overrides any decisions made in processTrack.   MWH
-            //}
+            if (info->hasTrackerHit()) {
+                G4ThreeVector vertex= aTrack->GetVertexPosition();
+                double vertex_z = vertex.z();
+                if(vertex_z < 1000.){
+                info->setSaveFlag(true);  /// ====> This effectively overrides any decisions made in processTrack.   MWH
+                }
+            }
 
             // Store trajectory if info has save flag turned on.
             if (info->getSaveFlag()) {

--- a/include/UserTrackingAction.h
+++ b/include/UserTrackingAction.h
@@ -71,7 +71,7 @@ class UserTrackingAction : public G4UserTrackingAction {
             if (info->hasTrackerHit()) {
                 G4ThreeVector vertex= aTrack->GetVertexPosition();
                 double vertex_z = vertex.z();
-                if(vertex_z < 1000.){
+                if(vertex_z < 1000.){     // FIXME: hard coded cut distance -- Need a way to set this from the command macro using a general messenger.
                 info->setSaveFlag(true);  /// ====> This effectively overrides any decisions made in processTrack.   MWH
                 }
             }

--- a/include/UserTrackingAction.h
+++ b/include/UserTrackingAction.h
@@ -21,6 +21,7 @@
 #include "TrackMap.h"
 #include "UserPrimaryParticleInformation.h"
 #include "UserTrackInformation.h"
+#include "Trajectory.h"
 
 namespace hpssim {
 
@@ -67,9 +68,9 @@ class UserTrackingAction : public G4UserTrackingAction {
 
             // Save tracks with tracker hits.
             // This flag is used by LCDD tracker detectors.
-            if (info->hasTrackerHit()) {
-                info->setSaveFlag(true);
-            }
+            //if (info->hasTrackerHit()) {
+                // info->setSaveFlag(true);  /// ====> This effectively overrides any decisions made in processTrack.   MWH
+            //}
 
             // Store trajectory if info has save flag turned on.
             if (info->getSaveFlag()) {
@@ -135,7 +136,7 @@ class UserTrackingAction : public G4UserTrackingAction {
             //if (isPrimary) {
             //    std::cout << "UserTrackingAction: Track " << aTrack->GetTrackID() << " is a primary." << std::endl;
             //}
-            if ((regionInfo && regionInfo->getStoreSecondaries()) || isPrimary) {
+           if ((regionInfo && regionInfo->getStoreSecondaries() && ( aTrack->GetKineticEnergy() > regionInfo->getThreshold())) || isPrimary) {
                 /*
                 if (regionInfo && regionInfo->getStoreSecondaries()) {
                     std::cout << "UserTrackingAction: Storing trajectory for " << aTrack->GetTrackID() << " in region "

--- a/src/LcioPersistencyManager.cxx
+++ b/src/LcioPersistencyManager.cxx
@@ -375,9 +375,9 @@ IMPL::LCCollectionVec* LcioPersistencyManager::writeCalorimeterHitsCollection(G4
     if (m_verbose > 2) {
         std::cout << "LcioPersistencyManager: Converting " << nhits << " calorimeter hits to LCIO" << std::endl;
     }
-    for (int i = 0; i < nhits; i++) {
+    for (int i_hit = 0; i_hit < nhits; ++i_hit) {
 
-        auto calHit = static_cast<CalorimeterHit*>(calHits->GetHit(i));
+        auto calHit = static_cast<CalorimeterHit*>(calHits->GetHit(i_hit));
         auto simCalHit = new IMPL::SimCalorimeterHitImpl();
 
         // set cellid from cal hit's id64
@@ -456,11 +456,11 @@ IMPL::LCCollectionVec* LcioPersistencyManager::writeCalorimeterHitsCollection(G4
                 pdg_check = pdg;
                 
                 const float* contribPos  = contrib.getPosition();
-                for(int i=0;i<3;++i) contribPos_ave[i] +=contribPos[i];
+                for(int j=0;j<3;++j) contribPos_ave[j] +=contribPos[j];
                 num_contribs++;
             }
             
-            for(int i=0;i<3;++i) contribPos_ave[i]=contribPos_ave[i]/num_contribs;
+            for(int j=0;j<3;++j) contribPos_ave[j]=contribPos_ave[j]/num_contribs;
             // Find the first parent track with a trajectory; it could actually be this track.  // FIXME: This should not be needed again.
             G4VTrajectory* traj = builder_->getTrackMap().findTrajectory(map_item.first);
             if (!traj) {


### PR DESCRIPTION
This issue resolves some critical problem with the energy stored for ECal hits, and the number of MCParticles kept by hps-sim. 
After these changes, the result from hps-sim is nearly identical to that from SLIC.

Bradley's analysis (red = hps-sim, blue=slic, green=data) shows how close hps-sim and slic are. 

![all_energy](https://user-images.githubusercontent.com/4603874/47224121-be81f100-d388-11e8-8962-f5369ca53553.png)

![all_px](https://user-images.githubusercontent.com/4603874/47224213-f1c48000-d388-11e8-843d-8a3976c3287f.png)

![all_py](https://user-images.githubusercontent.com/4603874/47224216-f5580700-d388-11e8-83c9-320cfce3fe2c.png)

 