### PR TITLE
Fixed the MCParticle energy issue, but not the number stored.

### DIFF
--- a/include/LcioMergeTool.h
+++ b/include/LcioMergeTool.h
@@ -74,7 +74,7 @@ class LcioMergeTool {
 
                 bool accept(EVENT::LCEvent* event) {
                     auto hits = event->getCollection(collName_);
-                    float e;
+                    float e=0;
                     for (int iElem = 0; iElem < hits->getNumberOfElements(); iElem++) {
                         EVENT::SimCalorimeterHit* hit =
                                 static_cast<EVENT::SimCalorimeterHit*>(hits->getElementAt(iElem));

--- a/src/MCParticleBuilder.cxx
+++ b/src/MCParticleBuilder.cxx
@@ -41,7 +41,7 @@ void MCParticleBuilder::buildMCParticle(Trajectory* traj) {
     p->setGeneratorStatus(traj->getGenStatus());
     p->setPDG(traj->GetPDGEncoding());
     p->setCharge(traj->GetCharge());
-    p->setMass(traj->getMass());
+    p->setMass(traj->getMass()/GeV);
     //p->setEnergy(traj->getEnergy());
     p->setTime(traj->getGlobalTime());
 


### PR DESCRIPTION
This is a very minor fix, only addressing the error in the energy of the MCParticle.

A new issue will look into properly handling the number of MCParticles that are written, which is still too many to be generally useful.