### PR TITLE
Fix seg fault accessing trajectory points

### DIFF
--- a/include/Trajectory.h
+++ b/include/Trajectory.h
@@ -131,7 +131,7 @@ class Trajectory : public G4VTrajectory {
          * Get the trajectory end point [mm].
          * @return The trajectory end point.
          */
-        const G4ThreeVector& getEndPoint() const;
+        const G4ThreeVector getEndPoint() const;
 
         /**
          * Get the particle's energy [MeV].

--- a/src/Trajectory.cxx
+++ b/src/Trajectory.cxx
@@ -123,7 +123,7 @@ void Trajectory::MergeTrajectory(G4VTrajectory* secondTrajectory) {
     seco->trajPoints_->clear();
 }
 
-const G4ThreeVector& Trajectory::getEndPoint() const {
+const G4ThreeVector Trajectory::getEndPoint() const {
     return GetPoint(GetPointEntries() - 1)->GetPosition();
 }
 


### PR DESCRIPTION
Resolve #44 by returning G4ThreeVector object instead of a reference from Trajectory method.  Existing method does not seem to work correctly with recent gcc compiler.