### PR TITLE
Iss48: Add sim plugin for printing event information & a few additional fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ scratch/
 # Eclipse files
 .cproject
 .project
+.settings

--- a/plugins/EventPrintPlugin.cxx
+++ b/plugins/EventPrintPlugin.cxx
@@ -16,25 +16,14 @@
 
 namespace hpssim {
 
-/**
- * Class constructor.
- * Creates a messenger for the class.
- */
 EventPrintPlugin::EventPrintPlugin() {
     _pluginMessenger = new EventPrintPluginMessenger(this);
 }
 
-/**
- * Class destructor.
- * Deletes the messenger for the class.
- */
 EventPrintPlugin::~EventPrintPlugin() {
     delete _pluginMessenger;
 }
 
-/**
- * Get the name of the plugin.
- */
 std::string EventPrintPlugin::getName() {
     return "EventPrintPlugin";
 }
@@ -43,10 +32,6 @@ std::vector<SimPlugin::PluginAction> EventPrintPlugin::getActions() {
     return {SimPlugin::PluginAction::RUN, SimPlugin::PluginAction::EVENT, SimPlugin::PluginAction::PRIMARY};
 }
 
-/**
- * Print a start message with the run number.
- * @param aRun The current Geant4 run that is starting.
- */
 void EventPrintPlugin::beginRun(const G4Run* aRun) {
     if (enableStartRun_) {
         std::cout << prepend_ << " Start Run " << aRun->GetRunID() << " "
@@ -54,10 +39,6 @@ void EventPrintPlugin::beginRun(const G4Run* aRun) {
     }
 }
 
-/**
- * Print an end message with the run number.
- * @param aRun The current Geant4 run that is ending.
- */
 void EventPrintPlugin::endRun(const G4Run* aRun) {
     if (enableEndRun_) {
         std::cout << prepend_ << " End Run " << aRun->GetRunID() << " "
@@ -65,11 +46,6 @@ void EventPrintPlugin::endRun(const G4Run* aRun) {
     }
 }
 
-/**
- * Print a start event message.
- * Use the primary generator hook for the start event message so it appears as early as possible in output.
- * @param anEvent The Geant4 event that is starting.
- */
 void EventPrintPlugin::generatePrimary(G4Event* anEvent) {
     if (enableStartEvent_) {
         if (anEvent->GetEventID() % modulus_ == 0) {
@@ -79,10 +55,6 @@ void EventPrintPlugin::generatePrimary(G4Event* anEvent) {
     }
 }
 
-/**
- * Print an end event message.
- * @param anEvent The Geant4 event that is ending.
- */
 void EventPrintPlugin::endEvent(const G4Event* anEvent) {
     if (enableEndEvent_) {
         if (anEvent->GetEventID() % modulus_ == 0) {
@@ -92,68 +64,34 @@ void EventPrintPlugin::endEvent(const G4Event* anEvent) {
     }
 }
 
-/**
- * Set the character string to prepend to messages.
- * @param prepend The prepending string.
- */
 void EventPrintPlugin::setPrepend(std::string prepend) {
     prepend_ = prepend;
 }
 
-/**
- * Set the character string to append to messages.
- * @param append The appending string.
- */
 void EventPrintPlugin::setAppend(std::string append) {
     append_ = append;
 }
 
-/**
- * Set the modulus which determines how often to print event messages.
- * A modulus of 1 will print every event.
- * @param modulus The event print modulus.
- */
 void EventPrintPlugin::setModulus(unsigned modulus) {
     modulus_ = modulus;
 }
 
-/**
- * Set whether a message should print at end of run.
- * @param enableEndRun True to enable end of run print out.
- */
 void EventPrintPlugin::setEnableEndRun(bool enableEndRun) {
     enableEndRun_ = enableEndRun;
 }
 
-/**
- * Set whether a message should print at start of run.
- * @param enableStartRun True to enable start of run print out.
- */
 void EventPrintPlugin::setEnableStartRun(bool enableStartRun) {
     enableStartRun_ = enableStartRun;
 }
 
-/**
- * Set whether a message should print at start of event.
- * @param enableStartEvent True to enable start of event print out.
- */
 void EventPrintPlugin::setEnableStartEvent(bool enableStartEvent) {
     enableStartEvent_ = enableStartEvent;
 }
 
-/**
- * Set whether a message should print at end of event.
- * @param enableEndEvent True to enable end of event print out.
- */
 void EventPrintPlugin::setEnableEndEvent(bool enableEndEvent) {
     enableEndEvent_ = enableEndEvent;
 }
 
-/**
- * Reset the plugin state.
- * Turns on all print outs, sets modulus to 1, and restores
- * default prepend and append strings.
- */
 void EventPrintPlugin::reset() {
     enableStartRun_ = true;
     enableEndRun_ = true;
@@ -164,6 +102,6 @@ void EventPrintPlugin::reset() {
     append_ = "<<<";
 }
 
-} // namespace sim
+} // namespace hpssim
 
 SIM_PLUGIN(hpssim, EventPrintPlugin)

--- a/plugins/EventPrintPlugin.cxx
+++ b/plugins/EventPrintPlugin.cxx
@@ -1,0 +1,169 @@
+/**
+ * @file EventPrintPlugin.h
+ * @brief Class that defines a sim plugin to print out event information
+ * @author Jeremy McCormick, SLAC National Accelerator Laboratory
+ */
+
+// HPS
+#include "EventPrintPlugin.h"
+#include "EventPrintPluginMessenger.h"
+
+// Geant4
+#include "G4UImessenger.hh"
+
+// STL
+#include <string>
+
+namespace hpssim {
+
+/**
+ * Class constructor.
+ * Creates a messenger for the class.
+ */
+EventPrintPlugin::EventPrintPlugin() {
+    _pluginMessenger = new EventPrintPluginMessenger(this);
+}
+
+/**
+ * Class destructor.
+ * Deletes the messenger for the class.
+ */
+EventPrintPlugin::~EventPrintPlugin() {
+    delete _pluginMessenger;
+}
+
+/**
+ * Get the name of the plugin.
+ */
+std::string EventPrintPlugin::getName() {
+    return "EventPrintPlugin";
+}
+
+std::vector<SimPlugin::PluginAction> EventPrintPlugin::getActions() {
+    return {SimPlugin::PluginAction::RUN, SimPlugin::PluginAction::EVENT, SimPlugin::PluginAction::PRIMARY};
+}
+
+/**
+ * Print a start message with the run number.
+ * @param aRun The current Geant4 run that is starting.
+ */
+void EventPrintPlugin::beginRun(const G4Run* aRun) {
+    if (enableStartRun_) {
+        std::cout << prepend_ << " Start Run " << aRun->GetRunID() << " "
+                << append_ << std::endl;
+    }
+}
+
+/**
+ * Print an end message with the run number.
+ * @param aRun The current Geant4 run that is ending.
+ */
+void EventPrintPlugin::endRun(const G4Run* aRun) {
+    if (enableEndRun_) {
+        std::cout << prepend_ << " End Run " << aRun->GetRunID() << " "
+                << append_ << std::endl;
+    }
+}
+
+/**
+ * Print a start event message.
+ * Use the primary generator hook for the start event message so it appears as early as possible in output.
+ * @param anEvent The Geant4 event that is starting.
+ */
+void EventPrintPlugin::generatePrimary(G4Event* anEvent) {
+    if (enableStartEvent_) {
+        if (anEvent->GetEventID() % modulus_ == 0) {
+            std::cout << prepend_ << " Start Event " << anEvent->GetEventID()
+                    << " " << append_ << std::endl;
+        }
+    }
+}
+
+/**
+ * Print an end event message.
+ * @param anEvent The Geant4 event that is ending.
+ */
+void EventPrintPlugin::endEvent(const G4Event* anEvent) {
+    if (enableEndEvent_) {
+        if (anEvent->GetEventID() % modulus_ == 0) {
+            std::cout << prepend_ << " End Event " << anEvent->GetEventID()
+                    << " " << append_ << std::endl;
+        }
+    }
+}
+
+/**
+ * Set the character string to prepend to messages.
+ * @param prepend The prepending string.
+ */
+void EventPrintPlugin::setPrepend(std::string prepend) {
+    prepend_ = prepend;
+}
+
+/**
+ * Set the character string to append to messages.
+ * @param append The appending string.
+ */
+void EventPrintPlugin::setAppend(std::string append) {
+    append_ = append;
+}
+
+/**
+ * Set the modulus which determines how often to print event messages.
+ * A modulus of 1 will print every event.
+ * @param modulus The event print modulus.
+ */
+void EventPrintPlugin::setModulus(unsigned modulus) {
+    modulus_ = modulus;
+}
+
+/**
+ * Set whether a message should print at end of run.
+ * @param enableEndRun True to enable end of run print out.
+ */
+void EventPrintPlugin::setEnableEndRun(bool enableEndRun) {
+    enableEndRun_ = enableEndRun;
+}
+
+/**
+ * Set whether a message should print at start of run.
+ * @param enableStartRun True to enable start of run print out.
+ */
+void EventPrintPlugin::setEnableStartRun(bool enableStartRun) {
+    enableStartRun_ = enableStartRun;
+}
+
+/**
+ * Set whether a message should print at start of event.
+ * @param enableStartEvent True to enable start of event print out.
+ */
+void EventPrintPlugin::setEnableStartEvent(bool enableStartEvent) {
+    enableStartEvent_ = enableStartEvent;
+}
+
+/**
+ * Set whether a message should print at end of event.
+ * @param enableEndEvent True to enable end of event print out.
+ */
+void EventPrintPlugin::setEnableEndEvent(bool enableEndEvent) {
+    enableEndEvent_ = enableEndEvent;
+}
+
+/**
+ * Reset the plugin state.
+ * Turns on all print outs, sets modulus to 1, and restores
+ * default prepend and append strings.
+ */
+void EventPrintPlugin::reset() {
+    enableStartRun_ = true;
+    enableEndRun_ = true;
+    enableEndEvent_ = true;
+    enableStartEvent_ = true;
+    modulus_ = 1;
+    prepend_ = ">>>";
+    append_ = "<<<";
+}
+
+} // namespace sim
+
+SIM_PLUGIN(hpssim, EventPrintPlugin)

--- a/plugins/EventPrintPlugin.h
+++ b/plugins/EventPrintPlugin.h
@@ -1,0 +1,168 @@
+/**
+ * @file EventPrintPluginMessenger.h
+ * @brief Class that defines a Geant4 messenger for the EventPrintPlugin
+ * @author Jeremy McCormick, SLAC National Accelerator Laboratory
+ */
+
+#ifndef HPSSIM_EVENTPRINTPLUGIN_H_
+#define HPSSIM_EVENTPRINTPLUGIN_H_
+
+// HPS
+#include "SimPlugin.h"
+
+// Geant4
+#include "G4UImessenger.hh"
+
+// STL
+#include <string>
+
+namespace hpssim {
+
+/**
+ * @class EventPrintPlugin
+ * @brief Sim plugin for printing out messages at begin and end of event and run
+ */
+class EventPrintPlugin: public SimPlugin {
+
+    public:
+
+        /**
+         * Class constructor.
+         * Creates a messenger for the class.
+         */
+        EventPrintPlugin();
+
+        /**
+         * Class destructor.
+         * Deletes the messenger for the class.
+         */
+        virtual ~EventPrintPlugin();
+
+        /**
+         * Get the name of the plugin.
+         */
+        virtual std::string getName();
+
+        std::vector<PluginAction> getActions();
+
+        /**
+         * Print a start message with the run number.
+         * @param aRun The current Geant4 run that is starting.
+         */
+        void beginRun(const G4Run* aRun);
+
+        /**
+         * Print an end message with the run number.
+         * @param aRun The current Geant4 run that is ending.
+         */
+        void endRun(const G4Run* aRun);
+
+        /**
+         * Print a start event message.
+         * Use the primary generator hook for the start event message so it appears as early as possible in output.
+         * @param anEvent The Geant4 event that is starting.
+         */
+        void generatePrimary(G4Event* anEvent);
+
+        /**
+         * Print an end event message.
+         * @param anEvent The Geant4 event that is ending.
+         */
+        void endEvent(const G4Event* anEvent);
+
+        /**
+         * Set the character string to prepend to messages.
+         * @param prepend The prepending string.
+         */
+        void setPrepend(std::string prepend);
+
+        /**
+         * Set the character string to append to messages.
+         * @param append The appending string.
+         */
+        void setAppend(std::string append);
+
+        /**
+         * Set the modulus which determines how often to print event messages.
+         * A modulus of 1 will print every event.
+         * @param modulus The event print modulus.
+         */
+        void setModulus(unsigned modulus);
+
+        /**
+         * Set whether a message should print at end of run.
+         * @param enableEndRun True to enable end of run print out.
+         */
+        void setEnableEndRun(bool enableEndRun);
+
+        /**
+         * Set whether a message should print at start of run.
+         * @param enableStartRun True to enable start of run print out.
+         */
+        void setEnableStartRun(bool enableStartRun);
+
+        /**
+         * Set whether a message should print at start of event.
+         * @param enableStartEvent True to enable start of event print out.
+         */
+        void setEnableStartEvent(bool enableStartEvent);
+
+        /**
+         * Set whether a message should print at end of event.
+         * @param enableEndEvent True to enable end of event print out.
+         */
+        void setEnableEndEvent(bool enableEndEvent);
+
+        /**
+         * Reset the plugin state.
+         * Turns on all print outs, sets modulus to 1, and restores
+         * default prepend and append strings.
+         */
+        void reset();
+
+    private:
+
+        /**
+         * The messenger for setting plugin parameters.
+         */
+        G4UImessenger* _pluginMessenger;
+
+        /**
+         * The event print modulus.
+         */
+        int modulus_ { 1 };
+
+        /**
+         * The prepending character string.
+         */
+        std::string prepend_ { ">>>" };
+
+        /**
+         * The appending character string.
+         */
+        std::string append_ { "<<<" };
+
+        /**
+         * Flag to enable start of run print out.
+         */
+        bool enableStartRun_ { true };
+
+        /**
+         * Flag to enable end of run print out.
+         */
+        bool enableEndRun_ { true };
+
+        /**
+         * Flag to enable start of event print out.
+         */
+        bool enableStartEvent_ { true };
+
+        /**
+         * Flag to enable end of event print out.
+         */
+        bool enableEndEvent_ { true };
+};
+
+} // namespace hpssim
+
+#endif

--- a/plugins/EventPrintPlugin.h
+++ b/plugins/EventPrintPlugin.h
@@ -62,8 +62,8 @@ class EventPrintPlugin: public SimPlugin {
 
         /**
          * Print a start event message.
-         * Use the primary generator hook for the start event message
-         * so it appears as early as possible in output.
+         * Uses the primary generator hook for the start event message
+         * so that it appears as early as possible in output.
          * @param anEvent The Geant4 event that is starting.
          */
         void generatePrimary(G4Event* anEvent);

--- a/plugins/EventPrintPlugin.h
+++ b/plugins/EventPrintPlugin.h
@@ -43,6 +43,9 @@ class EventPrintPlugin: public SimPlugin {
          */
         virtual std::string getName();
 
+        /**
+         * Get the actions implemented by this plugin.
+         */
         std::vector<PluginAction> getActions();
 
         /**
@@ -59,7 +62,8 @@ class EventPrintPlugin: public SimPlugin {
 
         /**
          * Print a start event message.
-         * Use the primary generator hook for the start event message so it appears as early as possible in output.
+         * Use the primary generator hook for the start event message
+         * so it appears as early as possible in output.
          * @param anEvent The Geant4 event that is starting.
          */
         void generatePrimary(G4Event* anEvent);

--- a/plugins/EventPrintPluginMessenger.cxx
+++ b/plugins/EventPrintPluginMessenger.cxx
@@ -34,37 +34,34 @@ EventPrintPluginMessenger::EventPrintPluginMessenger(EventPrintPlugin* plugin) :
     appendCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
             G4ApplicationState::G4State_Idle);
 
-    enableStartRunCmd_ = new G4UIcommand(
+    enableStartRunCmd_ = new G4UIcmdWithABool(
             std::string(getPath() + "enableStartRun").c_str(), this);
-    G4UIparameter* enableStartRun = new G4UIparameter("enable", 'b', false);
-    enableStartRunCmd_->SetParameter(enableStartRun);
-    enableStartRunCmd_->SetGuidance(
-            "Enable or disable print out at start of run.");
+    enableStartRunCmd_->SetGuidance("Enable or disable print out at start of run.");
+    enableStartRunCmd_->SetParameterName("enable", true, false);
+    enableStartRunCmd_->SetDefaultValue(true);
     enableStartRunCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
             G4ApplicationState::G4State_Idle);
 
-    enableEndRunCmd_ = new G4UIcommand(
+    enableEndRunCmd_ = new G4UIcmdWithABool(
             std::string(getPath() + "enableEndRun").c_str(), this);
-    G4UIparameter* enableEndRun = new G4UIparameter("enable", 'b', false);
-    enableEndRunCmd_->SetParameter(enableEndRun);
     enableEndRunCmd_->SetGuidance("Enable or disable print out at end of run.");
+    enableStartRunCmd_->SetParameterName("enable", true, false);
+    enableStartRunCmd_->SetDefaultValue(true);
     enableEndRunCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
             G4ApplicationState::G4State_Idle);
 
-    enableStartEventCmd_ = new G4UIcommand(
+    enableStartEventCmd_ = new G4UIcmdWithABool(
             std::string(getPath() + "enableStartEvent").c_str(), this);
-    G4UIparameter* enableStartEvent = new G4UIparameter("enable", 'b', false);
-    enableStartEventCmd_->SetParameter(enableStartEvent);
-    enableStartEventCmd_->SetGuidance(
-            "Enable or disable print out at start of event.");
-    enableStartEventCmd_->AvailableForStates(
-            G4ApplicationState::G4State_PreInit,
+    enableStartEventCmd_->SetParameterName("enable", true, false);
+    enableStartEventCmd_->SetDefaultValue(true);
+    enableStartEventCmd_->SetGuidance("Enable or disable print out at start of event.");
+    enableStartEventCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
             G4ApplicationState::G4State_Idle);
 
-    enableEndEventCmd_ = new G4UIcommand(
+    enableEndEventCmd_ = new G4UIcmdWithABool(
             std::string(getPath() + "enableEndEvent").c_str(), this);
-    G4UIparameter* enableEndEvent = new G4UIparameter("enable", 'b', false);
-    enableEndEventCmd_->SetParameter(enableEndEvent);
+    enableEndEventCmd_->SetParameterName("enable", true, false);
+    enableEndEventCmd_->SetDefaultValue(true);
     enableEndEventCmd_->SetGuidance(
             "Enable or disable print out at end of event.");
     enableEndEventCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,

--- a/plugins/EventPrintPluginMessenger.cxx
+++ b/plugins/EventPrintPluginMessenger.cxx
@@ -1,0 +1,123 @@
+#include "EventPrintPluginMessenger.h"
+
+#include "EventPrintPlugin.h"
+
+#include <sstream>
+
+namespace hpssim {
+
+EventPrintPluginMessenger::EventPrintPluginMessenger(EventPrintPlugin* plugin) :
+        SimPluginMessenger(plugin), eventPrintPlugin_(plugin) {
+
+    modulusCmd_ = new G4UIcommand(std::string(getPath() + "modulus").c_str(),
+            this);
+    G4UIparameter* modulus = new G4UIparameter("modulus", 'i', false);
+    modulusCmd_->SetParameter(modulus);
+    modulusCmd_->SetGuidance(
+            "Set the modulus for event printing (1 for every event, 10 for every 10th event, etc.)");
+    modulusCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+
+    prependCmd_ = new G4UIcommand(std::string(getPath() + "prepend").c_str(),
+            this);
+    G4UIparameter* prepend = new G4UIparameter("prepend", 's', false);
+    prependCmd_->SetParameter(prepend);
+    prependCmd_->SetGuidance("Set the string prepended to the print outs.");
+    prependCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+
+    appendCmd_ = new G4UIcommand(std::string(getPath() + "append").c_str(),
+            this);
+    G4UIparameter* append = new G4UIparameter("append", 's', false);
+    appendCmd_->SetParameter(append);
+    appendCmd_->SetGuidance("Set the string appended to the print outs.");
+    appendCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+
+    enableStartRunCmd_ = new G4UIcommand(
+            std::string(getPath() + "enableStartRun").c_str(), this);
+    G4UIparameter* enableStartRun = new G4UIparameter("enable", 'b', false);
+    enableStartRunCmd_->SetParameter(enableStartRun);
+    enableStartRunCmd_->SetGuidance(
+            "Enable or disable print out at start of run.");
+    enableStartRunCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+
+    enableEndRunCmd_ = new G4UIcommand(
+            std::string(getPath() + "enableEndRun").c_str(), this);
+    G4UIparameter* enableEndRun = new G4UIparameter("enable", 'b', false);
+    enableEndRunCmd_->SetParameter(enableEndRun);
+    enableEndRunCmd_->SetGuidance("Enable or disable print out at end of run.");
+    enableEndRunCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+
+    enableStartEventCmd_ = new G4UIcommand(
+            std::string(getPath() + "enableStartEvent").c_str(), this);
+    G4UIparameter* enableStartEvent = new G4UIparameter("enable", 'b', false);
+    enableStartEventCmd_->SetParameter(enableStartEvent);
+    enableStartEventCmd_->SetGuidance(
+            "Enable or disable print out at start of event.");
+    enableStartEventCmd_->AvailableForStates(
+            G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+
+    enableEndEventCmd_ = new G4UIcommand(
+            std::string(getPath() + "enableEndEvent").c_str(), this);
+    G4UIparameter* enableEndEvent = new G4UIparameter("enable", 'b', false);
+    enableEndEventCmd_->SetParameter(enableEndEvent);
+    enableEndEventCmd_->SetGuidance(
+            "Enable or disable print out at end of event.");
+    enableEndEventCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+
+    resetCmd_ = new G4UIcommand(std::string(getPath() + "reset").c_str(), this);
+    resetCmd_->SetGuidance(
+            "Reset all plugin parameters back to default values.");
+    resetCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit,
+            G4ApplicationState::G4State_Idle);
+}
+
+EventPrintPluginMessenger::~EventPrintPluginMessenger() {
+    delete modulusCmd_;
+    delete prependCmd_;
+    delete appendCmd_;
+    delete enableStartRunCmd_;
+    delete enableEndRunCmd_;
+    delete enableStartEventCmd_;
+    delete enableEndEventCmd_;
+    delete resetCmd_;
+}
+
+void EventPrintPluginMessenger::SetNewValue(G4UIcommand *command,
+        G4String newValue) {
+
+    // Handles verbose command.
+    SimPluginMessenger::SetNewValue(command, newValue);
+
+    if (command == modulusCmd_) {
+        eventPrintPlugin_->setModulus(std::atoi(newValue));
+    } else if (command == prependCmd_) {
+        eventPrintPlugin_->setPrepend(newValue);
+    } else if (command == appendCmd_) {
+        eventPrintPlugin_->setAppend(newValue);
+    } else if (command == resetCmd_) {
+        eventPrintPlugin_->reset();
+    } else {
+        /**
+         * Process commands with a boolean argument.
+         */
+        bool enable;
+        std::istringstream(newValue) >> enable;
+        if (command == enableStartRunCmd_) {
+            eventPrintPlugin_->setEnableEndRun(enable);
+        } else if (command == enableEndRunCmd_) {
+            eventPrintPlugin_->setEnableStartRun(enable);
+        } else if (command == enableStartEventCmd_) {
+            eventPrintPlugin_->setEnableStartEvent(enable);
+        } else if (command == enableEndEventCmd_) {
+            eventPrintPlugin_->setEnableEndEvent(enable);
+        }
+    }
+}
+
+} // namespace sim

--- a/plugins/EventPrintPluginMessenger.h
+++ b/plugins/EventPrintPluginMessenger.h
@@ -1,0 +1,101 @@
+/**
+ * @file EventPrintPluginMessenger.h
+ * @brief Class that defines a macro messenger for an EventPrintPlugin
+ * @author Jeremy McCormick, SLAC National Accelerator Laboratory
+ */
+
+#ifndef HPSSIM_EVENTPRINTPLUGINMESSENGER_H_
+#define HPSSIM_EVENTPRINTPLUGINMESSENGER_H_
+
+// HPS
+#include "SimPluginMessenger.h"
+
+// Geant4
+#include "G4UIcommand.hh"
+#include "G4UIparameter.hh"
+
+namespace hpssim {
+
+/*
+ * Declare the plugin class because there is a circular dep between
+ * the plugin its messenger class.
+ */
+class EventPrintPlugin;
+
+/**
+ * @class EventPrintPluginMessenger
+ * @brief Messenger class for setting parameters of the EventPrintPlugin
+ */
+class EventPrintPluginMessenger: public SimPluginMessenger {
+
+    public:
+
+        /**
+         * Class constructor.
+         * @param plugin The associated EventPrintPlugin object.
+         */
+        EventPrintPluginMessenger(EventPrintPlugin* plugin);
+
+        /**
+         * Class destructor.
+         */
+        virtual ~EventPrintPluginMessenger();
+
+        /**
+         * Process the macro command.
+         * @param command The macro command.
+         * @param newValue The argument values.
+         */
+        void SetNewValue(G4UIcommand *command, G4String newValue);
+
+    private:
+
+        /**
+         * The associated user plugin.
+         */
+        EventPrintPlugin* eventPrintPlugin_;
+
+        /**
+         * Command for setting the event print modulus.
+         */
+        G4UIcommand* modulusCmd_;
+
+        /**
+         * Command for setting the prepend string.
+         */
+        G4UIcommand* prependCmd_;
+
+        /**
+         * Command for setting the append string.
+         */
+        G4UIcommand* appendCmd_;
+
+        /**
+         * Command for enabling start of run message.
+         */
+        G4UIcommand* enableStartRunCmd_;
+
+        /**
+         * Command for enabling end of run message.
+         */
+        G4UIcommand* enableEndRunCmd_;
+
+        /**
+         * Command for enabling start of event message.
+         */
+        G4UIcommand* enableStartEventCmd_;
+
+        /**
+         * Command for enabling end of event message.
+         */
+        G4UIcommand* enableEndEventCmd_;
+
+        /**
+         * Command for resetting the plugin state.
+         */
+        G4UIcommand* resetCmd_;
+};
+
+} // namespace sim
+
+#endif

--- a/plugins/EventPrintPluginMessenger.h
+++ b/plugins/EventPrintPluginMessenger.h
@@ -12,6 +12,7 @@
 
 // Geant4
 #include "G4UIcommand.hh"
+#include "G4UIcmdWithABool.hh"
 #include "G4UIparameter.hh"
 
 namespace hpssim {
@@ -73,22 +74,22 @@ class EventPrintPluginMessenger: public SimPluginMessenger {
         /**
          * Command for enabling start of run message.
          */
-        G4UIcommand* enableStartRunCmd_;
+        G4UIcmdWithABool* enableStartRunCmd_;
 
         /**
          * Command for enabling end of run message.
          */
-        G4UIcommand* enableEndRunCmd_;
+        G4UIcmdWithABool* enableEndRunCmd_;
 
         /**
          * Command for enabling start of event message.
          */
-        G4UIcommand* enableStartEventCmd_;
+        G4UIcmdWithABool* enableStartEventCmd_;
 
         /**
          * Command for enabling end of event message.
          */
-        G4UIcommand* enableEndEventCmd_;
+        G4UIcmdWithABool* enableEndEventCmd_;
 
         /**
          * Command for resetting the plugin state.

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -24,6 +24,10 @@ std::vector<PrimaryGenerator*>& PrimaryGeneratorAction::getGenerators() {
     return generators_;
 }
 
+/*
+ * FIXME: Improve performance of this method for simple cases
+ * when no overlay or event transformations are being applied.  --JM
+ */
 void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
 
     for (auto gen : generators_) {
@@ -32,16 +36,16 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
             std::cout << "PrimaryGeneratorAction: Running generator '" << gen->getName() << "'" << std::endl;
         }
 
-        if (gen->getName().compare("gps")  == 0) { 
-            
+        if (gen->getName().compare("gps")  == 0) {
+
             // Generate a primary vertex.
             gen->GeneratePrimaryVertex(anEvent);
 
             /*
              * FIXME: It seems like GPS events should be transformable.
-             * For now, continue instead of returning here, as the plugin
-             * manager still needs to be activated at the end of the method
-             * (and multiple exit points are bad).
+             * For now, continue instead of return as additional generators
+             * still need to be activated and bookkeeping methods need to
+             * be called at the end of generation.
              * --JM
              */
             continue;

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -1,5 +1,6 @@
 #include "PrimaryGeneratorAction.h"
 
+#include "PluginManager.h"
 
 namespace hpssim {
 
@@ -35,8 +36,15 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
             
             // Generate a primary vertex.
             gen->GeneratePrimaryVertex(anEvent);
-            return; 
-            
+
+            /*
+             * FIXME: It seems like GPS events should be transformable.
+             * For now, continue instead of returning here, as the plugin
+             * manager still needs to be activated at the end of the method
+             * (and multiple exit points are bad).
+             * --JM
+             */
+            continue;
         }
 
         // Get the list of event transforms to be applied to each generated event.
@@ -87,6 +95,9 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
 
     // Set the generator status on the primaries and attach a user info object, if needed.
     setGenStatus(anEvent);
+
+    // Activate sim plugins.
+    PluginManager::getPluginManager()->generatePrimary(anEvent);
 }
 
 void PrimaryGeneratorAction::addGenerator(PrimaryGenerator* generator) {

--- a/src/UserRunAction.cxx
+++ b/src/UserRunAction.cxx
@@ -26,6 +26,7 @@ void UserRunAction::BeginOfRunAction(const G4Run* aRun) {
     PluginManager::getPluginManager()->beginRun(aRun);
 }
 
-void UserRunAction::EndOfRunAction(const G4Run*) {
+void UserRunAction::EndOfRunAction(const G4Run* aRun) {
+    PluginManager::getPluginManager()->endRun(aRun);
 }
 }


### PR DESCRIPTION
- Adds EventPrintPlugin ported from ldmw-sw for printing informational message with event and run numbers during the simulation
- Add several missing calls to plugin manager to activate plugin callbacks
- Fix an issue with the event generation where GPS generator returned abruptly and caused bookkeeping errors with generator particles
- Minor addition to .gitignore to ignore Eclipse config dir