### PR TITLE
Set GDML_SCHEMA_DIR to point to LCDD installation

### DIFF
--- a/scripts/hps-sim-env.sh.in
+++ b/scripts/hps-sim-env.sh.in
@@ -7,13 +7,13 @@ then
     export LD_LIBRARY_PATH=$(dirname @CMAKE_CXX_COMPILER@)/../lib64:$LD_LIBRARY_PATH
 fi
 
-#export GDML_SCHEMA_DIR=@GDML_DIR@/schemas
+export GDML_SCHEMA_DIR=@LCDD_DIR@/share
 
 . @Geant4_DIR@/../../bin/geant4.sh
 
 export PATH=@CMAKE_INSTALL_PREFIX@/bin:$PATH
 
-echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+#echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 #echo "GDML_SCHEMA_DIR=$GDML_SCHEMA_DIR"
-env | grep G4 | sort
-which hps-sim
+#env | grep G4 | sort
+#which hps-sim


### PR DESCRIPTION
LCDD has been updated to install the schemas to `${CMAKE_INSTALL_PREFIX}/share/schemas`, and the hps-sim script is updated to point to the share directory where it can find them offline.

I have confirmed that this is working by inserting debug print outs into a local copy of GDML which indicates that the local files are found okay.

This should allow hps-sim to be run entirely offline.

This PR also comments out the print outs from the hps-sim setup script now so that it is silent.