### PR TITLE
Iss30: Allow user to set physics list

### DIFF
--- a/include/PhysicsMessenger.h
+++ b/include/PhysicsMessenger.h
@@ -13,6 +13,7 @@ namespace hpssim {
 
 /**
  * @class PhysicsMessenger
+ * @brief Messenger to allow setting of physics list.
  */
 class PhysicsMessenger : public G4UImessenger {
 

--- a/include/PhysicsMessenger.h
+++ b/include/PhysicsMessenger.h
@@ -1,0 +1,34 @@
+#ifndef HPSSIM_PHYSICSMESSENGER_H_
+#define HPSSIM_PHYSICSMESSENGER_H_
+
+/*
+ * Geant4
+ */
+#include "G4UImessenger.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcmdWithAString.hh"
+
+namespace hpssim {
+
+/**
+ * @class PhysicsMessenger
+ */
+class PhysicsMessenger : public G4UImessenger {
+
+    public:
+
+        PhysicsMessenger();
+
+        virtual ~PhysicsMessenger();
+
+        void SetNewValue(G4UIcommand* command, G4String newValues);
+
+    private:
+
+        G4UIdirectory* physicsDir_;
+        G4UIcmdWithAString* physicsListCmd_;
+};
+
+} // namespace hpssim
+
+#endif

--- a/include/PhysicsMessenger.h
+++ b/include/PhysicsMessenger.h
@@ -7,6 +7,7 @@
 #include "G4UImessenger.hh"
 #include "G4UIdirectory.hh"
 #include "G4UIcmdWithAString.hh"
+#include "G4PhysListFactory.hh"
 
 namespace hpssim {
 
@@ -17,15 +18,34 @@ class PhysicsMessenger : public G4UImessenger {
 
     public:
 
-        PhysicsMessenger();
+        /**
+         * Class constructor.
+         * @brief Needs a reference to PhysListFactory for setting up guidance.
+         */
+        PhysicsMessenger(G4PhysListFactory*);
 
+        /**
+         * Class destructor.
+         */
         virtual ~PhysicsMessenger();
 
+        /**
+         * Handle messenger commands.
+         * @note Currently, this only sets the name of the physics list
+         * with the run manager.
+         */
         void SetNewValue(G4UIcommand* command, G4String newValues);
 
     private:
 
+        /**
+         * UI dir for physics commands.
+         */
         G4UIdirectory* physicsDir_;
+
+        /**
+         * UI command to set name of physics list.
+         */
         G4UIcmdWithAString* physicsListCmd_;
 };
 

--- a/include/RunManager.h
+++ b/include/RunManager.h
@@ -1,21 +1,64 @@
 #ifndef HPSSIM_RUNMANAGER_H_
 #define HPSSIM_RUNMANAGER_H_
 
+/*
+ * Geant4
+ */
 #include "G4RunManager.hh"
+#include "G4StateManager.hh"
+#include "G4PhysListFactory.hh"
 
-#include "UnknownDecayPhysics.h"
+/**
+ * HPS
+ */
+#include "PluginManager.h"
+#include "PhysicsMessenger.h"
 
 namespace hpssim {
 
-    class RunManager : public G4RunManager {
+/*
+ * @class RunManager
+ * @brief Custom Geant4 run manager implementation
+ */
+class RunManager: public G4RunManager {
 
-        public:
+    public:
 
-            void InitializePhysics();
-    };
+        RunManager();
+
+        virtual ~RunManager();
+
+        static RunManager* getRunManager() {
+            return static_cast<RunManager*>(G4RunManager::GetRunManager());
+        }
+
+        void setupPhysList();
+
+        void setPhysListName(const std::string& physListName) {
+            physListName_ = physListName;
+        }
+
+        /*
+        void Initialize() {
+            auto stateMgr = G4StateManager::GetStateManager();
+            std::cout << "RunManager is initializing ..." << std::endl;
+            std::cout << "state: "
+                    << stateMgr->GetStateString(stateMgr->GetCurrentState())
+                    << std::endl;
+            G4RunManager::Initialize();
+            std::cout << "RunManager is done initializing!" << std::endl;
+            std::cout << "state: "
+                    << stateMgr->GetStateString(stateMgr->GetCurrentState())
+                    << std::endl;
+        }
+        */
+
+    private:
+
+        std::string physListName_{"FTFP_BERT"};
+        G4UImessenger* physicsMessenger_{new PhysicsMessenger};
+        G4PhysListFactory* physListFactory_{new G4PhysListFactory};
+};
 }
-
-
-
 
 #endif

--- a/include/RunManager.h
+++ b/include/RunManager.h
@@ -2,15 +2,20 @@
 #define HPSSIM_RUNMANAGER_H_
 
 /*
+ * HPS
+ */
+#include "lcdd/core/LCDDDetectorConstruction.hh"
+
+/*
  * Geant4
  */
 #include "G4RunManager.hh"
-#include "G4StateManager.hh"
 #include "G4PhysListFactory.hh"
 
 /**
  * HPS
  */
+#include "LcioPersistencyManager.h"
 #include "PluginManager.h"
 #include "PhysicsMessenger.h"
 
@@ -24,40 +29,78 @@ class RunManager: public G4RunManager {
 
     public:
 
+        /**
+         * Class constructor.
+         * @note Creates the plugin manager.
+         */
         RunManager();
 
+        /**
+         * Class destructor.
+         */
         virtual ~RunManager();
 
+        /**
+         * Get the instance of the custom run manager.
+         */
         static RunManager* getRunManager() {
             return static_cast<RunManager*>(G4RunManager::GetRunManager());
         }
 
-        void setupPhysList();
-
+        /**
+         * Set the name of the physics list.
+         * @param physListName The name of the physics list.
+         * @note Only available in the preinit state.
+         */
         void setPhysListName(const std::string& physListName) {
             physListName_ = physListName;
         }
 
-        /*
-        void Initialize() {
-            auto stateMgr = G4StateManager::GetStateManager();
-            std::cout << "RunManager is initializing ..." << std::endl;
-            std::cout << "state: "
-                    << stateMgr->GetStateString(stateMgr->GetCurrentState())
-                    << std::endl;
-            G4RunManager::Initialize();
-            std::cout << "RunManager is done initializing!" << std::endl;
-            std::cout << "state: "
-                    << stateMgr->GetStateString(stateMgr->GetCurrentState())
-                    << std::endl;
+        /**
+         * Get a pointer to the physics list factory.
+         */
+        G4PhysListFactory* getPhysListFactory() {
+            return physListFactory_;
         }
-        */
+
+        /**
+         * Initialize the run manager.
+         */
+        void Initialize();
 
     private:
 
+        /**
+         * Setup the modular physics list.
+         */
+        void setupPhysList();
+
+    private:
+
+        /**
+         * Name of the physics list with default.
+         */
         std::string physListName_{"FTFP_BERT"};
-        G4UImessenger* physicsMessenger_{new PhysicsMessenger};
-        G4PhysListFactory* physListFactory_{new G4PhysListFactory};
+
+        /**
+         * Messenger for setting the name of the physics list.
+         */
+        G4UImessenger* physicsMessenger_{nullptr};
+
+        /**
+         * Factory class for instantiating the physics list.
+         */
+        G4PhysListFactory* physListFactory_{nullptr};
+
+        /**
+         * LCIO persistency manager.
+         */
+        LcioPersistencyManager* lcioMgr_{nullptr};
+
+        /**
+         * User detector construction.
+         */
+        LCDDDetectorConstruction* detectorConstruction_{nullptr};
 };
 }
 

--- a/src/PhysicsMessenger.cxx
+++ b/src/PhysicsMessenger.cxx
@@ -1,0 +1,24 @@
+#include "PhysicsMessenger.h"
+
+#include "RunManager.h"
+
+namespace hpssim {
+
+PhysicsMessenger::PhysicsMessenger() {
+    physicsDir_ = new G4UIdirectory("/hps/physics/", this);
+
+    physicsListCmd_ = new G4UIcmdWithAString("/hps/physics/list", this);
+    physicsListCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit);
+}
+
+PhysicsMessenger::~PhysicsMessenger() {
+    delete physicsListCmd_;
+}
+
+void PhysicsMessenger::SetNewValue(G4UIcommand* command, G4String newValues) {
+    if (command == physicsListCmd_) {
+        RunManager::getRunManager()->setPhysListName(newValues);
+    }
+}
+
+} // namespace hpssim

--- a/src/PhysicsMessenger.cxx
+++ b/src/PhysicsMessenger.cxx
@@ -1,14 +1,32 @@
 #include "PhysicsMessenger.h"
 
+/*
+ * HPS
+ */
 #include "RunManager.h"
+
+/*
+ * C++
+ */
+#include <sstream>
 
 namespace hpssim {
 
-PhysicsMessenger::PhysicsMessenger() {
+PhysicsMessenger::PhysicsMessenger(G4PhysListFactory* fac) {
+
     physicsDir_ = new G4UIdirectory("/hps/physics/", this);
 
     physicsListCmd_ = new G4UIcmdWithAString("/hps/physics/list", this);
     physicsListCmd_->AvailableForStates(G4ApplicationState::G4State_PreInit);
+    physicsListCmd_->SetGuidance("Set the name of the Geant4 reference physics list.");
+
+    // Setup guidance with names of available physics lists.
+    auto param = physicsListCmd_->GetParameter(0);
+    std::stringstream ss;
+    for (const G4String& listName : fac->AvailablePhysLists()) {
+        ss << listName << " ";
+    }
+    param->SetGuidance(ss.str().c_str());
 }
 
 PhysicsMessenger::~PhysicsMessenger() {

--- a/src/RunManager.cxx
+++ b/src/RunManager.cxx
@@ -59,31 +59,6 @@ void RunManager::setupPhysList() {
     std::cout << "Done creating physics list!" << std::endl;
 }
 
-/*
-void RunManager::InitializePhysics() {
-
-    // Call the G4RunManager's intitialization method.
-    G4RunManager::InitializePhysics();
-
-    // Check if the LCDD subsystem got some limits.
-    LCDDProcessor* lcdd = LCDDProcessor::instance();
-    PhysicsListManager* pmgr = PhysicsListManager::instance();
-    if (lcdd->getLimitSetsBegin() != lcdd->getLimitSetsEnd()) {
-        std::cout << "enabling phys limits" << std::endl;
-        pmgr->enableLimits(true);
-    }
-
-    // Enable physics limits, if necessary.
-    if (pmgr->enableLimits()) {
-        std::cout << "setting up user limits processes" << std::endl;
-        pmgr->setupUserLimitsProcesses();
-    }
-
-    // Print out particle table.
-    //G4ParticleTable::GetParticleTable()->DumpTable();
-}
-*/
-
 void RunManager::Initialize() {
 
     setupPhysList();
@@ -98,7 +73,7 @@ void RunManager::Initialize() {
     SetUserAction(new SteppingAction);
     SetUserAction(new UserStackingAction);
 
-    // Create the persistency manager.
+    // Create the persistency manager (must go here to get pointer to track map).
     lcioMgr_ = new LcioPersistencyManager();
 }
 

--- a/src/RunManager.cxx
+++ b/src/RunManager.cxx
@@ -1,28 +1,105 @@
 #include "RunManager.h"
 
 /*
+ * LCDD
+ */
+#include "lcdd/core/LCDDDetectorConstruction.hh"
+
+/*
  * HPS
  */
+#include "RunManager.h"
+#include "PrimaryGeneratorAction.h"
+#include "SteppingAction.h"
+#include "UserTrackingAction.h"
+#include "UserRunAction.h"
+#include "UserEventAction.h"
+#include "UserStackingAction.h"
 #include "UnknownDecayPhysics.h"
 
 namespace hpssim {
 
 RunManager::RunManager() : G4RunManager() {
+
     // Make sure plugin manager is initialized.
     auto pluginMgr = PluginManager::getPluginManager();
+
+    // Setup messenger for physics list.
+    physListFactory_ = new G4PhysListFactory;
+    physicsMessenger_ = new PhysicsMessenger(physListFactory_);
+
+    // Setup detector construction.
+    detectorConstruction_ = new LCDDDetectorConstruction();
+    SetUserInitialization(detectorConstruction_);
 }
 
 RunManager::~RunManager() {
     delete physicsMessenger_;
     delete physListFactory_;
+    delete lcioMgr_;
 }
 
 void RunManager::setupPhysList() {
-    std::cout << "Setting up physics list '" << physListName_ << "' ..." << std::endl;
+    std::cout << "Creating physics list '" << physListName_ << "' ..." << std::endl;
+
+    /*
+     * Setup physics list and throw a fatal error if the name is invalid.
+     */
+    if (!physListFactory_->IsReferencePhysList(physListName_)) {
+        G4Exception("RunManager::setupPhysList", "", FatalException,
+                G4String("Invalid reference physics list: " + physListName_));
+    }
     auto physList = physListFactory_->GetReferencePhysList(physListName_);
+
+    // TODO: Add messenger command to toggle this extra physics on/off.
     physList->RegisterPhysics(new UnknownDecayPhysics);
+
     this->SetUserInitialization(physList);
-    std::cout << "Setup physics list '" << physListName_ << "' successfully!" << std::endl;
+
+    std::cout << "Done creating physics list!" << std::endl;
+}
+
+/*
+void RunManager::InitializePhysics() {
+
+    // Call the G4RunManager's intitialization method.
+    G4RunManager::InitializePhysics();
+
+    // Check if the LCDD subsystem got some limits.
+    LCDDProcessor* lcdd = LCDDProcessor::instance();
+    PhysicsListManager* pmgr = PhysicsListManager::instance();
+    if (lcdd->getLimitSetsBegin() != lcdd->getLimitSetsEnd()) {
+        std::cout << "enabling phys limits" << std::endl;
+        pmgr->enableLimits(true);
+    }
+
+    // Enable physics limits, if necessary.
+    if (pmgr->enableLimits()) {
+        std::cout << "setting up user limits processes" << std::endl;
+        pmgr->setupUserLimitsProcesses();
+    }
+
+    // Print out particle table.
+    //G4ParticleTable::GetParticleTable()->DumpTable();
+}
+*/
+
+void RunManager::Initialize() {
+
+    setupPhysList();
+
+    G4RunManager::Initialize();
+
+    // Register all user action classes with the run manager.
+    SetUserAction(new PrimaryGeneratorAction);
+    SetUserAction(new UserTrackingAction);
+    SetUserAction(new UserRunAction);
+    SetUserAction(new UserEventAction);
+    SetUserAction(new SteppingAction);
+    SetUserAction(new UserStackingAction);
+
+    // Create the persistency manager.
+    lcioMgr_ = new LcioPersistencyManager();
 }
 
 }

--- a/src/RunManager.cxx
+++ b/src/RunManager.cxx
@@ -1,19 +1,28 @@
 #include "RunManager.h"
 
+/*
+ * HPS
+ */
 #include "UnknownDecayPhysics.h"
-
-#include "FTFP_BERT.hh"
 
 namespace hpssim {
 
-void RunManager::InitializePhysics() {
-// Don't do anything here until "state" issues are resolved.
-/*
-    G4VUserPhysicsList* thePhysicsList = new FTFP_BERT;
-    G4VModularPhysicsList* modularPhysicsList = dynamic_cast<G4VModularPhysicsList*>(thePhysicsList);
-    modularPhysicsList->RegisterPhysics(new UnknownDecayPhysics);
-    G4RunManager::InitializePhysics();
-*/
+RunManager::RunManager() : G4RunManager() {
+    // Make sure plugin manager is initialized.
+    auto pluginMgr = PluginManager::getPluginManager();
+}
+
+RunManager::~RunManager() {
+    delete physicsMessenger_;
+    delete physListFactory_;
+}
+
+void RunManager::setupPhysList() {
+    std::cout << "Setting up physics list '" << physListName_ << "' ..." << std::endl;
+    auto physList = physListFactory_->GetReferencePhysList(physListName_);
+    physList->RegisterPhysics(new UnknownDecayPhysics);
+    this->SetUserInitialization(physList);
+    std::cout << "Setup physics list '" << physListName_ << "' successfully!" << std::endl;
 }
 
 }

--- a/src/hps-sim.cxx
+++ b/src/hps-sim.cxx
@@ -6,30 +6,15 @@
 /*
  * Geant4
  */
-#include "G4RunManager.hh"
 #include "G4UIExecutive.hh"
 #include "G4UImanager.hh"
 #include "G4VisManager.hh"
 #include "G4VisExecutive.hh"
 
 /*
- * LCDD
- */
-//#include "lcdd/core/LCDDDetectorConstruction.hh"
-
-/*
  * HPS
  */
 #include "RunManager.h"
-/*
-#include "LcioPersistencyManager.h"
-#include "SteppingAction.h"
-#include "PrimaryGeneratorAction.h"
-#include "UserTrackingAction.h"
-#include "UserRunAction.h"
-#include "UserEventAction.h"
-#include "UserStackingAction.h"
-*/
 
 using namespace hpssim;
 
@@ -51,23 +36,6 @@ int main(int argc, char* argv[]) {
     // Setup the user detector construction.
     LCDDDetectorConstruction* det = new LCDDDetectorConstruction();
 
-    // Setup the physics list.
-    //mgr->setupPhysList();
-
-    /*
-
-    // Register all user action classes with the run manager.
-    mgr->SetUserAction(new PrimaryGeneratorAction);
-    mgr->SetUserAction(new UserTrackingAction);
-    mgr->SetUserAction(new UserRunAction);
-    mgr->SetUserAction(new UserEventAction);
-    mgr->SetUserAction(new SteppingAction);
-    mgr->SetUserAction(new UserStackingAction);
-
-    // Create the persistency manager.
-    LcioPersistencyManager* lcio = new LcioPersistencyManager();
-    */
-
     // Initialize the visualization engine.
     G4VisManager* vis = new G4VisExecutive;
     vis->Initialize();
@@ -84,9 +52,6 @@ int main(int argc, char* argv[]) {
         UIExec->SessionStart();
         delete UIExec;
     }
-
-    // Delete the persistency manager.
-    //delete lcio;
 
     // Delete the run manager.
     delete mgr;

--- a/src/hps-sim.cxx
+++ b/src/hps-sim.cxx
@@ -33,9 +33,6 @@ int main(int argc, char* argv[]) {
     // Initialize the custom run manager.
     RunManager* mgr = new RunManager();
 
-    // Setup the user detector construction.
-    LCDDDetectorConstruction* det = new LCDDDetectorConstruction();
-
     // Initialize the visualization engine.
     G4VisManager* vis = new G4VisExecutive;
     vis->Initialize();

--- a/src/hps-sim.cxx
+++ b/src/hps-sim.cxx
@@ -1,5 +1,8 @@
 #include <iostream>
 
+/*
+ * Geant4
+ */
 #include "FTFP_BERT.hh"
 #include "G4RunManager.hh"
 #include "G4UIExecutive.hh"
@@ -7,12 +10,18 @@
 #include "G4VisManager.hh"
 #include "G4VisExecutive.hh"
 
+/*
+ * LCDD
+ */
 #include "lcdd/core/LCDDDetectorConstruction.hh"
 
+/*
+ * HPS
+ */
 #include "SteppingAction.h"
 #include "LcioPersistencyManager.h"
-#include "PluginManager.h"
 #include "PrimaryGeneratorAction.h"
+#include "RunManager.h"
 #include "UserTrackingAction.h"
 #include "UserRunAction.h"
 #include "UserEventAction.h"
@@ -30,17 +39,16 @@ int main(int argc, char* argv[]) {
         UIExec = new G4UIExecutive(argc, argv);
     }
 
-    G4RunManager* mgr = new G4RunManager;
+    std::cout << "Setting up RunManager ..." << std::endl;
+    RunManager* mgr = new RunManager();
+    std::cout << "Done setting up RunManager!" << std::endl;
 
-    auto pluginMgr = PluginManager::getPluginManager();
-
-    auto physicsList = new FTFP_BERT;
-    G4VModularPhysicsList* modularPhysicsList = dynamic_cast<G4VModularPhysicsList*>(physicsList);
-    modularPhysicsList->RegisterPhysics(new UnknownDecayPhysics);
-    mgr->SetUserInitialization(physicsList);
+    mgr->setupPhysList();
+    std::cout << "Done setting up phys list" << std::endl;
 
     LCDDDetectorConstruction* det = new LCDDDetectorConstruction();
     mgr->SetUserInitialization(det);
+    std::cout << "Registered detector construction" << std::endl;
 
     mgr->SetUserAction(new PrimaryGeneratorAction);
     mgr->SetUserAction(new UserTrackingAction);
@@ -48,11 +56,14 @@ int main(int argc, char* argv[]) {
     mgr->SetUserAction(new UserEventAction);
     mgr->SetUserAction(new SteppingAction);
     mgr->SetUserAction(new UserStackingAction);
+    std::cout << "Registered user actions" << std::endl;
 
     LcioPersistencyManager* lcio = new LcioPersistencyManager();
+    std::cout << "Created persistency manager" << std::endl;
 
     G4VisManager* vis = new G4VisExecutive;
     vis->Initialize();
+    std::cout << "Initialized vis engine" << std::endl;
 
     G4UImanager* UImgr = G4UImanager::GetUIpointer();
 
@@ -66,6 +77,8 @@ int main(int argc, char* argv[]) {
         UIExec->SessionStart();
         delete UIExec;
     }
+
+    std::cout << "Application is exiting ..." << std::endl;
 
     delete lcio;
     delete mgr;

--- a/src/hps-sim.cxx
+++ b/src/hps-sim.cxx
@@ -1,9 +1,11 @@
+/*
+ * C++
+ */
 #include <iostream>
 
 /*
  * Geant4
  */
-#include "FTFP_BERT.hh"
 #include "G4RunManager.hh"
 #include "G4UIExecutive.hh"
 #include "G4UImanager.hh"
@@ -13,75 +15,79 @@
 /*
  * LCDD
  */
-#include "lcdd/core/LCDDDetectorConstruction.hh"
+//#include "lcdd/core/LCDDDetectorConstruction.hh"
 
 /*
  * HPS
  */
-#include "SteppingAction.h"
-#include "LcioPersistencyManager.h"
-#include "PrimaryGeneratorAction.h"
 #include "RunManager.h"
+/*
+#include "LcioPersistencyManager.h"
+#include "SteppingAction.h"
+#include "PrimaryGeneratorAction.h"
 #include "UserTrackingAction.h"
 #include "UserRunAction.h"
 #include "UserEventAction.h"
 #include "UserStackingAction.h"
-#include "UnknownDecayPhysics.h"
+*/
 
 using namespace hpssim;
 
+/**
+ * Application's main entry point which performs all required setup of Geant4
+ * and custom user classes in the correct initialization order.
+ */
 int main(int argc, char* argv[]) {
 
-    std::cout << "Hello hps-sim!" << std::endl;
-
+    // Create the Geant4 UI executive to process macro commands.
     G4UIExecutive* UIExec = 0;
     if (argc == 1) {
         UIExec = new G4UIExecutive(argc, argv);
     }
 
-    std::cout << "Setting up RunManager ..." << std::endl;
+    // Initialize the custom run manager.
     RunManager* mgr = new RunManager();
-    std::cout << "Done setting up RunManager!" << std::endl;
 
-    mgr->setupPhysList();
-    std::cout << "Done setting up phys list" << std::endl;
-
+    // Setup the user detector construction.
     LCDDDetectorConstruction* det = new LCDDDetectorConstruction();
-    mgr->SetUserInitialization(det);
-    std::cout << "Registered detector construction" << std::endl;
 
+    // Setup the physics list.
+    //mgr->setupPhysList();
+
+    /*
+
+    // Register all user action classes with the run manager.
     mgr->SetUserAction(new PrimaryGeneratorAction);
     mgr->SetUserAction(new UserTrackingAction);
     mgr->SetUserAction(new UserRunAction);
     mgr->SetUserAction(new UserEventAction);
     mgr->SetUserAction(new SteppingAction);
     mgr->SetUserAction(new UserStackingAction);
-    std::cout << "Registered user actions" << std::endl;
 
+    // Create the persistency manager.
     LcioPersistencyManager* lcio = new LcioPersistencyManager();
-    std::cout << "Created persistency manager" << std::endl;
+    */
 
+    // Initialize the visualization engine.
     G4VisManager* vis = new G4VisExecutive;
     vis->Initialize();
-    std::cout << "Initialized vis engine" << std::endl;
 
+    // Execute the UI session to run the application.
     G4UImanager* UImgr = G4UImanager::GetUIpointer();
-
     if (UIExec == 0) {
         G4String command = "/control/execute ";
         G4String fileName = argv[1];
-        std::cout << "Executing macro " << fileName << " ..." << std::endl;
+        //std::cout << "Executing macro " << fileName << " ..." << std::endl;
         UImgr->ApplyCommand(command + fileName);
     } else {
-        std::cout << "Starting interactive session ..." << std::endl;
+        //std::cout << "Starting interactive session ..." << std::endl;
         UIExec->SessionStart();
         delete UIExec;
     }
 
-    std::cout << "Application is exiting ..." << std::endl;
+    // Delete the persistency manager.
+    //delete lcio;
 
-    delete lcio;
+    // Delete the run manager.
     delete mgr;
-
-    std::cout << "Bye hps-sim!" << std::endl;
 }


### PR DESCRIPTION
These changes allow the user to set the name of the reference physics list.

Unfortunately, due to how convoluted the setup procedures are for initializing Geant4, a lot of code had to be reorganized in order to do this.

I have checked that this patch handles correctly:

- Using the default list (FTFP_BERT)
- Using a user-specified list
- Throwing a fatal error when an invalid list is specified

This should probably be merged after #52 and #49 though it may not matter.  